### PR TITLE
#1 Remove unused products output directory

### DIFF
--- a/src/main/java/com/cubrid/tools/ideaconfig/EntryPoint.java
+++ b/src/main/java/com/cubrid/tools/ideaconfig/EntryPoint.java
@@ -376,7 +376,6 @@ public class EntryPoint {
         // 4. Generate run configurations and runtime files
         RunConfigProducer runConfigProducer = new RunConfigProducer(
             pathsManager.getRunConfigurationsDir(),
-            pathsManager.getProductsOutputDir(),
             pathsManager.getEclipseDepsDir(),
             config.getWorkspaceName()
         );

--- a/src/main/java/com/cubrid/tools/ideaconfig/config/PathsManager.java
+++ b/src/main/java/com/cubrid/tools/ideaconfig/config/PathsManager.java
@@ -36,7 +36,6 @@ public class PathsManager {
     private Path modulesDir;
     private Path librariesDir;
     private Path runConfigurationsDir;
-    private Path productsOutputDir;
 
     public PathsManager(Path projectsFolder, Path outputDir, Path eclipseDepsDir, ProjectConfig config) {
         this.projectsFolder = projectsFolder.toAbsolutePath().normalize();
@@ -141,14 +140,12 @@ public class PathsManager {
         modulesDir = workspaceDir.resolve("modules");
         librariesDir = ideaConfigDir.resolve("libraries");
         runConfigurationsDir = ideaConfigDir.resolve("runConfigurations");
-        productsOutputDir = outputDir.resolve("products");
 
         log.debug("Output directories:");
         log.debug("  IDEA config: {}", ideaConfigDir);
         log.debug("  Modules: {}", modulesDir);
         log.debug("  Libraries: {}", librariesDir);
         log.debug("  Run configs: {}", runConfigurationsDir);
-        log.debug("  Products: {}", productsOutputDir);
     }
 
     /**
@@ -159,7 +156,6 @@ public class PathsManager {
         Files.createDirectories(modulesDir);
         Files.createDirectories(librariesDir);
         Files.createDirectories(runConfigurationsDir);
-        Files.createDirectories(productsOutputDir);
         log.info("Created output directories");
     }
 
@@ -299,10 +295,6 @@ public class PathsManager {
         return runConfigurationsDir;
     }
 
-    public Path getProductsOutputDir() {
-        return productsOutputDir;
-    }
-
     public Path getWorkspaceDir() {
         return outputDir.resolve(config.getWorkspaceName());
     }
@@ -329,12 +321,5 @@ public class PathsManager {
     public Path getRunConfigurationPath(String configName) {
         String safeName = configName.replaceAll("[^a-zA-Z0-9._-]", "_");
         return runConfigurationsDir.resolve(safeName + ".xml");
-    }
-
-    /**
-     * Get path for product output directory.
-     */
-    public Path getProductOutputPath(String productName) {
-        return productsOutputDir.resolve(productName);
     }
 }

--- a/src/main/java/com/cubrid/tools/ideaconfig/producer/RunConfigProducer.java
+++ b/src/main/java/com/cubrid/tools/ideaconfig/producer/RunConfigProducer.java
@@ -25,13 +25,11 @@ public class RunConfigProducer {
     private static final String EQUINOX_LAUNCHER_CLASS = "org.eclipse.equinox.launcher.Main";
 
     private final Path runConfigDir;
-    private final Path productsDir;
     private final Path eclipseDepsDir;
     private final String workspaceName;
 
-    public RunConfigProducer(Path runConfigDir, Path productsDir, Path eclipseDepsDir, String workspaceName) {
+    public RunConfigProducer(Path runConfigDir, Path eclipseDepsDir, String workspaceName) {
         this.runConfigDir = runConfigDir;
-        this.productsDir = productsDir;
         this.eclipseDepsDir = eclipseDepsDir;
         this.workspaceName = workspaceName;
     }


### PR DESCRIPTION
### Description
출력 폴더 내에 비어 있는 products 디렉터리를 생성하던 로직을 제거합니다.

### Key Changes
- PathsManager에서 productsOutputDir 정의 및 생성 로직 제거
- RunConfigProducer에서 사용되지 않는 productsDir 파라미터 제거
- 변경 사항을 반영하여 EntryPoint 수정